### PR TITLE
Préparation release 3.0.0

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,4 +6,4 @@
 
 ## Preview
 
-https://ansforge.github.io/IG-fhir-[nom repo]/[ajouter_nom_de_la_branche]/ig
+https://ansforge.github.io/interop-ig-fhir-notification-evenements/[ajouter_nom_de_la_branche]/ig

--- a/input/data/features.yml
+++ b/input/data/features.yml
@@ -4,4 +4,4 @@ feedback:
   - active: true
     dashboard:
       label: New Issue
-      url: https://github.com/ansforge/FIG_ans-ig-sample/issues/new
+      url: https://github.com/ansforge/interop-ig-fhir-notification-evenements/issues/new

--- a/input/pagecontent/change-log.md
+++ b/input/pagecontent/change-log.md
@@ -4,7 +4,7 @@
 
 URL : <https://interop.esante.gouv.fr/ig/fhir/nde/3.0.0>
 
-[Modifications apportées dans cette release](https://github.com/ansforge/interop-ig-fhir-notification-evenements/pulls?q=is%3Apr+is%3Aclosed) :
+[Modifications apportées dans cette release](https://github.com/ansforge/interop-ig-fhir-notification-evenements/milestone/1) :
 
 * Création de la structure de l'IG [#7](https://github.com/ansforge/interop-ig-fhir-notification-evenements/pull/7)
 * Ajout des spécifications fonctionnelles [#8](https://github.com/ansforge/interop-ig-fhir-notification-evenements/pull/8)

--- a/input/pagecontent/change-log.md
+++ b/input/pagecontent/change-log.md
@@ -1,9 +1,34 @@
-### version xxx
+### Version 3.0.0
 
-**Release xxx de l'Implementation Guide FHIR xxx.**
+**Première release de l'Implementation Guide FHIR Notification d'Événements.**
 
-URL : <https://interop.esante.gouv.fr/ig/fhir/xxx>
+URL : <https://interop.esante.gouv.fr/ig/fhir/nde/3.0.0>
 
-[Modifications apportées dans cette release](https://github.com/ansforge/xxx/milestone/10?closed=1) :
+[Modifications apportées dans cette release](https://github.com/ansforge/interop-ig-fhir-notification-evenements/pulls?q=is%3Apr+is%3Aclosed) :
 
-* [narratif] modification xxx [numéro d'issue](https://github.com/ansforge/xxx/issues/numéro d'issue)
+* Création de la structure de l'IG [#7](https://github.com/ansforge/interop-ig-fhir-notification-evenements/pull/7)
+* Ajout des spécifications fonctionnelles [#8](https://github.com/ansforge/interop-ig-fhir-notification-evenements/pull/8)
+* Ajout des normes et standards [#9](https://github.com/ansforge/interop-ig-fhir-notification-evenements/pull/9)
+* Ajout des spécifications techniques [#10](https://github.com/ansforge/interop-ig-fhir-notification-evenements/pull/10)
+* Ajout des ressources de conformité [#11](https://github.com/ansforge/interop-ig-fhir-notification-evenements/pull/11)
+* Préparation à la consultation [#13](https://github.com/ansforge/interop-ig-fhir-notification-evenements/pull/13)
+
+### Versions antérieures (spécifications PDF)
+
+Les versions ci-dessous correspondent aux spécifications publiées au format PDF sur le [site de l'ANS](https://esante.gouv.fr/volet-notification-devenements), avant la migration vers le format Implementation Guide FHIR.
+
+#### Spécifications techniques v2.1 — Avril 2022
+
+Consultable sur le site de l'ANS : [CISIS-TEC_SPECIFICATIONS_TECHNIQUES_NOTIFICATIONS_EVENEMENTS_v2.1.pdf](https://esante.gouv.fr/sites/default/files/media_entity/documents/cisis-tec_specifications_techniques_notifications_evenements_v2.1.pdf)
+
+#### Spécifications techniques v2.0 — Janvier 2021
+
+Consultable sur le site de l'ANS : [CISIS-TEC_SPECIFICATIONS_TECHNIQUES_NOTIFICATIONS_EVENEMENTS_V2.0.pdf](https://esante.gouv.fr/sites/default/files/media_entity/documents/CISIS-TEC_SPECIFICATIONS_TECHNIQUES_NOTIFICATIONS_EVENEMENTS_V2.0.pdf)
+
+#### Spécifications fonctionnelles v1.3 — Janvier 2021
+
+Consultable sur le site de l'ANS : [CISIS-TEC_SPECIFICATIONS_FONCTIONNELLES_NOTIFICATION_EVENEMENTS_v1.3.pdf](https://esante.gouv.fr/sites/default/files/media_entity/documents/CISIS-TEC_SPECIFICATIONS_FONCTIONNELLES_NOTIFICATION_EVENEMENTS_v1.3.pdf)
+
+#### Normes et Standards v1.1 — Avril 2018
+
+Consultable sur le site de l'ANS : [CI_SIS_STANDARDS_NOTIFICATION_EVENEMENTS_V1.1.pdf](https://esante.gouv.fr/sites/default/files/media_entity/documents/CI_SIS_STANDARDS_NOTIFICATION_EVENEMENTS_V1.1.pdf)

--- a/publication-request.json
+++ b/publication-request.json
@@ -2,7 +2,7 @@
     "package-id" : "ans.fhir.fr.nde",
     "version" : "3.0.0",
     "path" : "https://interop.esante.gouv.fr/ig/fhir/nde/3.0.0",
-    "mode" : "release",
+    "mode" : "milestone",
     "status" : "trial-use",
     "sequence" : "STU1",
     "title" : "Volet Traçabilité des notifications d'événements",

--- a/publication-request.json
+++ b/publication-request.json
@@ -1,16 +1,16 @@
 {
     "package-id" : "ans.fhir.fr.nde",
-    "version" : "3.0.0-ballot",
-    "path" : "https://interop.esante.gouv.fr/ig/fhir/nde/3.0.0-ballot",
-    "mode" : "working",
-    "status" : "ballot",
+    "version" : "3.0.0",
+    "path" : "https://interop.esante.gouv.fr/ig/fhir/nde/3.0.0",
+    "mode" : "release",
+    "status" : "trial-use",
     "sequence" : "STU1",
     "title" : "Volet Traçabilité des notifications d'événements",
     "first" : true,
-    "desc" : "Ce guide décrit les mechanismes de notification d’évènements.",
+    "desc" : "Ce guide décrit les mechanismes de notification d'évènements.",
     "ci-build" : "https://ansforge.github.io/interop-ig-fhir-notification-evenements/main/ig/",
     "category" : "Infrastructure",
-    "introduction" : "Ce guide décrit un mécanisme de notification d’évènements permettant d’informer automatiquement une personne lorsqu’un évènement survient au cours de sa prise en charge.",
+    "introduction" : "Ce guide décrit un mécanisme de notification d'évènements permettant d'informer automatiquement une personne lorsqu'un évènement survient au cours de sa prise en charge.",
     "changes": "change-log.html"
 
   }

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -11,7 +11,7 @@ status: active
 version: 3.0.0 # shall conforms to Semantic Versioning https://fr.wiktionary.org/wiki/SemVer
 fhirVersion: 4.0.1
 copyrightYear: 2020+
-releaseLabel: release # le release label doit être conforme au cycle de vie de la doctrine du ci-sis
+releaseLabel: trial-use # le release label doit être conforme au cycle de vie de la doctrine du ci-sis. Cf. https://interop.esante.gouv.fr/ig/documentation/mod_bonnes_pratiques.html#release-dun-ig-fhir colonne "label de publication"
 jurisdiction: urn:iso:std:iso:3166#FR "FRANCE"
 dependencies:
     hl7.fhir.fr.core: 2.1.0

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -7,11 +7,11 @@ title: Notification d'Événements
 publisher:
   name: Agence du Numérique en Santé (ANS) - 2-10 Rue d'Oradour-sur-Glane, 75015 Paris
   url: https://esante.gouv.fr
-status: draft
-version: 3.0.0-ballot # shall conforms to Semantic Versioning https://fr.wiktionary.org/wiki/SemVer
+status: active
+version: 3.0.0 # shall conforms to Semantic Versioning https://fr.wiktionary.org/wiki/SemVer
 fhirVersion: 4.0.1
 copyrightYear: 2020+
-releaseLabel: public-comment # le release label doit être conforme au cycle de vie de la doctrine du ci-sis
+releaseLabel: release # le release label doit être conforme au cycle de vie de la doctrine du ci-sis
 jurisdiction: urn:iso:std:iso:3166#FR "FRANCE"
 dependencies:
     hl7.fhir.fr.core: 2.1.0


### PR DESCRIPTION
## Description des changements

* [sushi-config] Version `3.0.0-ballot` → `3.0.0`, status `draft` → `active`, releaseLabel `public-comment` → `release`
* [publication-request] Version, path, mode (`working` → `release`) et status (`ballot` → `trial-use`) mis à jour pour la release 3.0.0
* [change-log] Mise à jour avec les PRs mergées et l'historique des versions PDF antérieures
* [pr-template] URL de preview corrigée avec le nom du repo (`FIG_ans-ig-sample` → `interop-ig-fhir-notification-evenements`)
* [input/data] URL de création d'issue corrigée avec le nom du repo (`FIG_ans-ig-sample` → `interop-ig-fhir-notification-evenements`)

## Preview

[https://ansforge.github.io/interop-ig-fhir-notification-evenements/nr-prepare-release/ig](https://ansforge.github.io/interop-ig-fhir-notification-evenements/nr-prepare-release/ig)